### PR TITLE
Various fixes

### DIFF
--- a/src/blocks/owc-openkaarten/streetmap/block.json
+++ b/src/blocks/owc-openkaarten/streetmap/block.json
@@ -12,7 +12,7 @@
           "default" : ""
         },
         "selected_datasets" : {
-            "type" : "Array",
+            "type" : "array",
             "default" : []
         }
     },

--- a/src/blocks/owc-openkaarten/streetmap/template.php
+++ b/src/blocks/owc-openkaarten/streetmap/template.php
@@ -47,7 +47,7 @@ echo wp_kses_post(
 			'id'               => 'owc-openkaarten-streetmap',
 			'class'            => 'owc-openkaarten-streetmap',
 			'data-endpoint'    => esc_url( $openkaarten_frontend_plugin_rest_uri ),
-			'data-title'       => esc_attr( $attributes['title'] ?: '' ),
+			'data-title'       => esc_attr( $attributes['title'] ?? '' ),
 			'data-dataset-ids' => esc_attr( wp_json_encode( $attributes['selected_datasets'] ) ?: '' ),
 		]
 	)


### PR DESCRIPTION
Hoi,

Het renderen van de kaart ging mis, dat had twee oorzaken:

- Een incorrect type in block.json
- Een 'title' attribute dat in mijn geval afwezig was

Voor wat betreft die laatste zie ik ook zo snel niet waar die attribute vandaan zou moeten komen, wellicht is deze fix niet de juiste. Maar daar komen jullie vast wel uit. ;)

In elk geval werkte het renderen van de kaart na deze twee changes.